### PR TITLE
Add Templates for PR and Issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,50 @@
+name: Bug Report
+description: File a bug report
+title: "[Bug] "
+labels: ["bug", "triage"]
+assignees:
+  - jbreidfjord
+body:
+  - type: textarea
+    attributes:
+      label: Expected Behaviour
+      description: A concise description of what you expected to happen.
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: Current Behaviour
+      description: A concise description of what the bug is.
+    validations:
+      required: true
+  - type: dropdown
+    attributes:
+      label: Build
+      description: What build does the bug occur, live or preview?
+      options:
+        - Live
+        - Preview
+    validations:
+      required: true
+  - type: input
+    attributes:
+      label: Preview PR
+      description: If preview, please reference the associated PR.
+    validations:
+      required: false
+  - type: textarea
+    attributes:
+      label: Steps to Reproduce
+      description: Steps necessary to have the bug occur.
+      placeholder: |
+        1. Logged into/out of account...
+        2. On this page...
+        3. Doing this action...
+      validations:
+        required: true
+  - type: textarea
+    attributes:
+      label: Additional Info
+      description: Any other info that you think would be useful.
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -47,4 +47,4 @@ body:
       label: Additional Info
       description: Any other info that you think would be useful.
     validations:
-      required: true
+      required: false

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -40,8 +40,8 @@ body:
         1. Logged into/out of account...
         2. On this page...
         3. Doing this action...
-      validations:
-        required: true
+    validations:
+      required: true
   - type: textarea
     attributes:
       label: Additional Info

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,25 @@
+name: Feature Request
+description: Request a new feature
+title: "[Feature] "
+labels: ["feature"]
+assignees:
+  - jbreidfjord
+body:
+  - type: textarea
+    attributes:
+      label: Desired Behaviour
+      description: A description of the behaviour or functionality you want implemented.
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: Current Behaviour
+      description: Is this a change to an existing behaviour? If so, please describe the changes and how it would be improved.
+    validations:
+      required: false
+  - type: textarea
+    attributes:
+      label: Additional Info
+      description: Any other info that you think would be useful. If requesting a visual change, consider submitting an image mockup of the change.
+    validations:
+      required: false

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,14 @@
+<!--- Provide a general summary of your changes in the Title above -->
+
+## Description
+<!--- Describe your changes in detail -->
+
+## Motivation and Context
+<!--- Why is this change required? What problem does it solve? -->
+<!--- If it fixes an open issue, please link to the issue here. -->
+
+## Types of changes
+<!--- What types of changes does your code introduce? Check all that apply: -->
+- [ ] Bug fix (non-breaking change which fixes an issue)
+- [ ] New feature (non-breaking change which adds functionality)
+- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### PR DESCRIPTION
Use github templates to provide default issue and PR templates.