### PR TITLE
Reduce Data Upload

### DIFF
--- a/src/hooks/useFirestore.js
+++ b/src/hooks/useFirestore.js
@@ -1,7 +1,13 @@
-import { addDoc, collection, deleteDoc, doc, setDoc, updateDoc } from "firebase/firestore";
+import {
+  addDoc,
+  collection,
+  deleteDoc,
+  doc,
+  getFirestore,
+  setDoc,
+  updateDoc,
+} from "firebase/firestore";
 import { useEffect, useReducer, useState } from "react";
-
-import { db } from "../firebase/config";
 
 const firestoreReducer = (state, action) => {
   switch (action.type) {
@@ -24,7 +30,7 @@ export const useFirestore = (collectionName) => {
   });
   const [isCancelled, setIsCancelled] = useState(false);
 
-  const collectionRef = collection(db, collectionName);
+  const collectionRef = collection(getFirestore(), collectionName);
 
   const dispatchIfNotCancelled = (action) => {
     if (!isCancelled) {
@@ -45,7 +51,7 @@ export const useFirestore = (collectionName) => {
   const deleteDocument = async (id) => {
     dispatchIfNotCancelled({ type: "PENDING" });
     try {
-      await deleteDoc(doc(db, collectionName, id));
+      await deleteDoc(doc(getFirestore(), collectionName, id));
       dispatchIfNotCancelled({ type: "SUCCESS" });
     } catch (err) {
       dispatchIfNotCancelled({ type: "ERROR", payload: err.message });
@@ -55,7 +61,7 @@ export const useFirestore = (collectionName) => {
   const updateDocument = async (id, updates) => {
     dispatchIfNotCancelled({ type: "PENDING" });
     try {
-      await updateDoc(doc(db, collectionName, id), updates);
+      await updateDoc(doc(getFirestore(), collectionName, id), updates);
       dispatchIfNotCancelled({ type: "SUCCESS" });
     } catch (err) {
       dispatchIfNotCancelled({ type: "ERROR", payload: err.message });

--- a/src/hooks/useStorage.js
+++ b/src/hooks/useStorage.js
@@ -1,9 +1,6 @@
-import { doc, setDoc } from "firebase/firestore";
-import { getDownloadURL, ref, uploadBytes } from "firebase/storage";
+import { doc, getFirestore, setDoc } from "firebase/firestore";
+import { getDownloadURL, getStorage, ref, uploadBytes } from "firebase/storage";
 import { useCallback, useEffect, useState } from "react";
-
-import { getFirestore } from "firebase/firestore";
-import { getStorage } from "firebase/storage";
 
 const pako = require("pako");
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Prevents data from being uploaded if no new data has been added

## Description
<!--- Describe your changes in detail -->
Added check for data length, if data hasn't changed only the user's Firestore document should be updated without sending all of their data back to storage

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Saves bandwidth, preventing unnecessary costs

## Types of changes
<!--- What types of changes does your code introduce? Check all that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
