### PR TITLE
Fix Fetch Crash for Logged Out Users

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -2,8 +2,8 @@ rules_version = '2';
 service cloud.firestore {
   match /databases/{database}/documents {
     match /{document=**} {
-      allow read, write: if
-          request.time < timestamp.date(2022, 2, 3);
+      allow read;
+      allow write: if request.auth != null;
     }
   }
 }

--- a/storage.rules
+++ b/storage.rules
@@ -2,7 +2,8 @@ rules_version = '2';
 service firebase.storage {
   match /b/{bucket}/o {
     match /{allPaths=**} {
-      allow read, write: if request.auth!=null;
+      allow read;
+      allow write: if request.auth != null;
     }
   }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Fixes a crash when fetching data while not logged in.

## Description
<!--- Describe your changes in detail -->
Updated firestore and cloud storage rules to allow reads without auth, and updated Home to check for auth before uploading data.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Resolves #18

## Types of changes
<!--- What types of changes does your code introduce? Check all that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
